### PR TITLE
Updated package.json to reflect the proper Apache license desc

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     },
     "licenses": [
         {
-            "type": "ALv2",
-            "url": "xxxxxxxxxxxxxxxxxxxx"
+            "type": "Apache-2.0",
+            "url": "http://www.apache.org/licenses/LICENSE-2.0"
         }
     ],
     "dependencies": {


### PR DESCRIPTION
Applying the defaults from the Apache Thrift project for the license settings in package.json

See:
https://svn.apache.org/repos/asf/thrift/trunk/lib/nodejs/package.json
