### PR TITLE
Pipeline - don't create undefined pipes. AGJS-75

### DIFF
--- a/src/aerogear.core.js
+++ b/src/aerogear.core.js
@@ -41,6 +41,7 @@ AeroGear.Core = function() {
         var i,
             current,
             collection = this[ this.collectionName ] || {};
+        this[ this.collectionName ] = collection;
 
         if ( !config ) {
             return this;
@@ -69,7 +70,7 @@ AeroGear.Core = function() {
         }
 
         // reset the collection instance
-        this[ this.collectionName ] = Object.keys( collection ).length ? collection : undefined;
+        this[ this.collectionName ] = collection;
 
         return this;
     };

--- a/tests/unit/pipeline/pipeline-rest.js
+++ b/tests/unit/pipeline/pipeline-rest.js
@@ -6,21 +6,21 @@ test( "create - Empty Pipeline", function() {
     expect( 1 );
 
     var pipeline = AeroGear.Pipeline();
-    equal( pipeline.pipes, undefined, "Empty Pipeline Created" );
+    equal( Object.keys( pipeline.pipes ).length, 0, "Empty Pipeline Created" );
 });
 
 test( "create - Empty Pipeline - with Config", function() {
     expect( 1 );
 
     var pipeline = AeroGear.Pipeline({ type: "Rest" });
-    equal( pipeline.pipes, undefined, "Empty Pipeline Created" );
+    equal( Object.keys( pipeline.pipes ).length, 0, "Empty Pipeline Created" );
 });
 
 test( "create - Empty Pipeline - with Config as Array", function() {
     expect( 1 );
 
     var pipeline = AeroGear.Pipeline([{ type: "Rest" }]);
-    equal( pipeline.pipes, undefined, "Empty Pipeline Created" );
+    equal( Object.keys( pipeline.pipes ).length, 0, "Empty Pipeline Created" );
 });
 
 test( "create - Pipeline - with Config as Array - 2 pipes - one with no name", function() {


### PR DESCRIPTION
see https://issues.jboss.org/browse/AGJS-75

when doing this:

```
var pipeline = AeroGear.Pipeline({ type: "Rest"});
```

an undefined pipe is actually created.  modified a bit of core and added some tests.  

basically it looks to make sure the name property is there

Haven't checked if this more that just Pipeline
