### PR TITLE
Inclusion of retire.js to scan vulnerabilities

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -162,6 +162,12 @@ module.exports = function(grunt) {
                     }
                 }
             }
+        },
+        retire: {
+          /** Scan js-files in app/src/ directory and subdirectories. **/
+          js: ['src/aerogear.core.js', 'external/uuid/uuid.js', 'external/base64/base64.js', 'external/crypto/sjcl.js', 'src/pipeline/aerogear.pipeline.js', 'src/pipeline/adapters/rest.js', 'src/data-manager/aerogear.datamanager.js', 'src/data-manager/adapters/memory.js', 'src/data-manager/adapters/session-local.js', 'src/data-manager/adapters/indexeddb.js', 'src/data-manager/adapters/websql.js', 'src/authentication/aerogear.auth.js', 'src/authentication/adapters/rest.js', 'src/notifier/aerogear.notifier.js', 'src/notifier/adapters/simplePush.js', 'src/notifier/adapters/vertx.js', 'src/notifier/adapters/stompws.js', 'src/unifiedpush/aerogear.unifiedpush.js', 'src/simplepush/aerogear.simplepush.js', 'src/crypto/aerogear.crypto.js'],
+          options: {
+          }
         }
     });
 
@@ -181,9 +187,10 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-qunit');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-shell');
+    grunt.loadNpmTasks('grunt-retire');
 
     // Default task
-    grunt.registerTask('default', ['jshint', 'qunit', 'concat:dist', 'iife', 'uglify:all']);
+    grunt.registerTask('default', ['jshint', 'qunit', 'retire', 'concat:dist', 'iife', 'uglify:all']);
     grunt.registerTask('dev', ['jshint', 'concat:dist', 'iife', 'uglify:all']);
     grunt.registerTask('pipeline', ['jshint', 'qunit', 'concat:pipeline', 'iife:custom', 'uglify:custom']);
     grunt.registerTask('data-manager', ['jshint', 'qunit', 'concat:dataManager', 'iife:custom', 'uglify:custom']);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "grunt-contrib-uglify": "~0.1.2",
     "grunt-contrib-qunit": "~0.1.1",
     "grunt-shell": "0.3.1",
+    "grunt-retire": "0.1.12",
     "grunt": "~0.4.1",
     "request": "~2.27.0"
   },


### PR DESCRIPTION
Aloha, I'm not sure how handy it could be to you but this PR adds a vulnerability scanner to the JS libs. For further details please check http://bekk.github.io/retire.js/
