### PR TITLE
Crypto - Refactor to allow for future state in the crypto lib

### DIFF
--- a/src/crypto/aerogear.crypto.js
+++ b/src/crypto/aerogear.crypto.js
@@ -14,11 +14,11 @@
 * limitations under the License.
 */
 
-AeroGear.crypto = function() {
+AeroGear.Crypto = function() {
 
     // Allow instantiation without using new
-    if ( !( this instanceof AeroGear.crypto ) ) {
-        return new AeroGear.crypto();
+    if ( !( this instanceof AeroGear.Crypto ) ) {
+        return new AeroGear.Crypto();
     }
 
     // Local Variables

--- a/tests/unit/crypto/aerogear.crypto.js
+++ b/tests/unit/crypto/aerogear.crypto.js
@@ -5,8 +5,8 @@ module( "PBKDF2 - Password-based key derivation" );
 test( "Password validation with random salt provided", function() {
 
     var hex = sjcl.codec.hex,
-        rawPassword = AeroGear.crypto().deriveKey( PASSWORD ),
-        newRawPassword = AeroGear.crypto().deriveKey( PASSWORD );
+        rawPassword = AeroGear.Crypto().deriveKey( PASSWORD ),
+        newRawPassword = AeroGear.Crypto().deriveKey( PASSWORD );
 
     notEqual( hex.fromBits( rawPassword ), hex.fromBits( newRawPassword ), "Password is the same" );
 
@@ -16,7 +16,7 @@ module( "Password based encrytion with GCM" );
 
 test( "Encrypt/Decrypt raw bytes providing password", function() {
 
-    var rawPassword = AeroGear.crypto().deriveKey( PASSWORD ),
+    var rawPassword = AeroGear.Crypto().deriveKey( PASSWORD ),
         utf8String = sjcl.codec.utf8String,
         hex = sjcl.codec.hex,
         cipherText,
@@ -26,15 +26,15 @@ test( "Encrypt/Decrypt raw bytes providing password", function() {
             key: rawPassword,
             data: utf8String.toBits( PLAIN_TEXT )
     };
-    cipherText = AeroGear.crypto().encrypt( options );
+    cipherText = AeroGear.Crypto().encrypt( options );
     options.data = cipherText;
-    plainText = AeroGear.crypto().decrypt ( options );
+    plainText = AeroGear.Crypto().decrypt ( options );
     equal( utf8String.fromBits( plainText ), PLAIN_TEXT, "Encryption has failed" );
 });
 
 test( "Encrypt/Decrypt raw bytes providing corrupted password", function() {
 
-    var rawPassword = AeroGear.crypto().deriveKey( PASSWORD ),
+    var rawPassword = AeroGear.Crypto().deriveKey( PASSWORD ),
         utf8String = sjcl.codec.utf8String,
         hex = sjcl.codec.hex,
         cipherText,
@@ -44,12 +44,12 @@ test( "Encrypt/Decrypt raw bytes providing corrupted password", function() {
             key: rawPassword,
             data: utf8String.toBits( PLAIN_TEXT )
     };
-    cipherText = AeroGear.crypto().encrypt( options );
+    cipherText = AeroGear.Crypto().encrypt( options );
     options.key[0] = ' ';
     options.data = cipherText;
 
     throws( function() {
-        AeroGear.crypto().decrypt ( options );
+        AeroGear.Crypto().decrypt ( options );
     }, "Should throw an exception for corrupted password");
 
 });
@@ -65,7 +65,7 @@ test( "Encrypt raw bytes", function() {
             key: hex.toBits( BOB_SECRET_KEY ),
             data: hex.toBits( MESSAGE )
     };
-    cipherText = AeroGear.crypto().encrypt( options );
+    cipherText = AeroGear.Crypto().encrypt( options );
     equal( hex.fromBits( cipherText ),  CIPHERTEXT, "Encryption has failed" );
 });
 
@@ -79,8 +79,8 @@ test( "Encrypt/Decrypt raw bytes", function() {
             key: hex.toBits( BOB_SECRET_KEY ),
             data: hex.toBits( MESSAGE )
         };
-    options.data = AeroGear.crypto().encrypt( options );
-    plainText = AeroGear.crypto().decrypt ( options );
+    options.data = AeroGear.Crypto().encrypt( options );
+    plainText = AeroGear.Crypto().decrypt ( options );
     equal( hex.fromBits( plainText ),  MESSAGE, "Encryption has failed" );
 });
 
@@ -92,11 +92,11 @@ test( "Decrypt corrupted ciphertext", function() {
             key: hex.toBits( BOB_SECRET_KEY ),
             data: hex.toBits( MESSAGE )
         };
-    options.data = AeroGear.crypto().encrypt( options );
+    options.data = AeroGear.Crypto().encrypt( options );
     options.data[23] = ' ';
 
     throws( function() {
-        AeroGear.crypto().decrypt ( options );
+        AeroGear.Crypto().decrypt ( options );
     }, "Should throw an exception for corrupted ciphertext");
 });
 
@@ -108,11 +108,11 @@ test( "Decrypt with corrupted IV", function() {
             key: hex.toBits( BOB_SECRET_KEY ),
             data: hex.toBits( MESSAGE )
         };
-    options.data = AeroGear.crypto().encrypt( options );
+    options.data = AeroGear.Crypto().encrypt( options );
     options.IV[23] = ' ';
 
     throws(function(){
-        AeroGear.crypto().decrypt ( options );
+        AeroGear.Crypto().decrypt ( options );
     }, "Should throw an exception for corrupted IVs");
 });
 
@@ -120,13 +120,13 @@ module( "Secure Hash Algorithm (SHA-256)" );
 
 test( "Should generated a valid SHA output", function() {
     var hex = sjcl.codec.hex,
-        digest = AeroGear.crypto().hash(SHA256_MESSAGE);
+        digest = AeroGear.Crypto().hash(SHA256_MESSAGE);
     equal( hex.fromBits( digest ),  SHA256_DIGEST, "Hash is invalid" );
 });
 
 test( "Should generated a valid SHA output for empty strings", function() {
     var hex = sjcl.codec.hex;
-        digest = AeroGear.crypto().hash("");
+        digest = AeroGear.Crypto().hash("");
     equal( hex.fromBits( digest ),  SHA256_DIGEST_EMPTY_STRING, "Hash is invalid" );
 });
 
@@ -138,8 +138,8 @@ test( "Should generate a valid signature", function() {
             keys: sjcl.ecc.ecdsa.generateKeys(192),
             message: PLAIN_TEXT
         };
-    options.signature = AeroGear.crypto().sign( options );
-    validation = AeroGear.crypto().verify( options );
+    options.signature = AeroGear.Crypto().sign( options );
+    validation = AeroGear.Crypto().verify( options );
 
     ok( validation, "Signature should be valid" );
 
@@ -150,11 +150,11 @@ test( "Should raise an error with corrupted key", function() {
         keys: sjcl.ecc.ecdsa.generateKeys(192),
         message: PLAIN_TEXT
     };
-    options.signature = AeroGear.crypto().sign( options );
+    options.signature = AeroGear.Crypto().sign( options );
     options.keys = sjcl.ecc.ecdsa.generateKeys(192,10);
 
     throws(function(){
-        AeroGear.crypto().verify( options );
+        AeroGear.Crypto().verify( options );
     }, "Should throw an exception for corrupted or wrong keys");
 });
 
@@ -163,11 +163,11 @@ test( "Should raise an error with corrupted signature", function() {
         keys: sjcl.ecc.ecdsa.generateKeys(192),
         message: PLAIN_TEXT
     };
-    options.signature = AeroGear.crypto().sign( options );
+    options.signature = AeroGear.Crypto().sign( options );
     options.signature[1] = ' ';
 
     throws(function(){
-        AeroGear.crypto().verify( options );
+        AeroGear.Crypto().verify( options );
     }, "Should throw an exception for corrupted signatures");
 });
 
@@ -175,7 +175,7 @@ module( "Asymmetric encryption with ECC" );
 
 test( "Encrypt/Decrypt raw bytes", function() {
     var hex = sjcl.codec.hex,
-        keyPair = new AeroGear.crypto().KeyPair(),
+        keyPair = new AeroGear.Crypto().KeyPair(),
         cipherText, plainText,
         options = {
             IV: hex.toBits( BOB_IV ),
@@ -183,16 +183,16 @@ test( "Encrypt/Decrypt raw bytes", function() {
             key: keyPair.getPublicKey(),
             data: hex.toBits( MESSAGE )
         };
-    cipherText = AeroGear.crypto().encrypt( options );
+    cipherText = AeroGear.Crypto().encrypt( options );
     options.key = keyPair.getPrivateKey();
     options.data = cipherText;
-    plainText = AeroGear.crypto().decrypt( options );
+    plainText = AeroGear.Crypto().decrypt( options );
     equal( hex.fromBits( plainText ),  MESSAGE, "Encryption has failed" );
 });
 
 test( "Decrypt corrupted ciphertext", function() {
     var hex = sjcl.codec.hex,
-        keyPair = new AeroGear.crypto().KeyPair(),
+        keyPair = new AeroGear.Crypto().KeyPair(),
         cipherText, plainText,
         options = {
             IV: hex.toBits( BOB_IV ),
@@ -200,18 +200,18 @@ test( "Decrypt corrupted ciphertext", function() {
             key: keyPair.getPublicKey(),
             data: hex.toBits( MESSAGE )
         };
-    options.data = AeroGear.crypto().encrypt( options );
+    options.data = AeroGear.Crypto().encrypt( options );
     options.data[23] = ' ';
     options.key = keyPair.getPrivateKey();
 
     throws( function() {
-        AeroGear.crypto().decrypt ( options );
+        AeroGear.Crypto().decrypt ( options );
     }, "Should throw an exception for corrupted ciphertext");
 });
 
 test( "Decrypt with corrupted IV", function() {
     var hex = sjcl.codec.hex,
-        keyPair = new AeroGear.crypto().KeyPair(),
+        keyPair = new AeroGear.Crypto().KeyPair(),
         cipherText, plainText,
         options = {
             IV: hex.toBits( BOB_IV ),
@@ -219,18 +219,18 @@ test( "Decrypt with corrupted IV", function() {
             key: keyPair.getPublicKey(),
             data: hex.toBits( MESSAGE )
         };
-    options.data = AeroGear.crypto().encrypt( options );
+    options.data = AeroGear.Crypto().encrypt( options );
     options.IV[23] = ' ';
     options.key = keyPair.getPrivateKey();
 
     throws( function() {
-        AeroGear.crypto().decrypt ( options );
+        AeroGear.Crypto().decrypt ( options );
     }, "Should throw an exception for corrupted IVs");
 });
 
 test( "Decrypt with the wrong key", function() {
     var hex = sjcl.codec.hex,
-        keyPair = new AeroGear.crypto().KeyPair(),
+        keyPair = new AeroGear.Crypto().KeyPair(),
         cipherText, plainText,
         options = {
             IV: hex.toBits( BOB_IV ),
@@ -238,11 +238,11 @@ test( "Decrypt with the wrong key", function() {
             key: keyPair.getPublicKey(),
             data: hex.toBits( MESSAGE )
         };
-    options.data = AeroGear.crypto().encrypt( options );
+    options.data = AeroGear.Crypto().encrypt( options );
     options.key = hex.toBits( BOB_PRIVATE_KEY );
 
     throws( function() {
-        AeroGear.crypto().decrypt( options );
+        AeroGear.Crypto().decrypt( options );
     }, "Should throw an exception for decryption with the wrong key");
 });
 


### PR DESCRIPTION
Now that we are thinking about adding "state", https://github.com/aerogear/aerogear-js/pull/76 and https://github.com/aerogear/aerogear-js/pull/77  we need to refactor the main crypto bits to now be instantiated.

This way variables won't leak  
