### PR TITLE
Add custom REST authentication module settings test & update doc comments in src

### DIFF
--- a/src/authentication/adapters/rest.js
+++ b/src/authentication/adapters/rest.js
@@ -28,16 +28,22 @@
 var auth = AeroGear.Auth();
 
 //Add a custom REST module to it
-auth.add( "module1", {
-    baseURL: "http://customURL.com"
+auth.add( {
+    name: "module1",
+    settings: {
+        baseURL: "http://customURL.com"
+    }
 });
 
 //Add a custom REST module to it with custom security endpoints
-auth.add( "module2", {
-    endpoints: {
-        enroll: "register",
-        login: "go",
-        logout: "leave"
+auth.add( {
+    name: "module2",
+    settings: {
+        endpoints: {
+            enroll: "register",
+            login: "go",
+            logout: "leave"
+        }
     }
 });
  */

--- a/tests/unit/authentication/authentication-rest.js
+++ b/tests/unit/authentication/authentication-rest.js
@@ -2,6 +2,32 @@
 
     module( "authentication" );
 
+    test( "Custom REST Authentication module init", function() {
+        expect( 7 );
+
+        var auth1 = AeroGear.Auth();
+
+        auth1.add( {
+            name: "module1", 
+            settings: {
+                baseURL: "http://customURL.com",
+                endpoints: {
+                    enroll: "register",
+                    login: "go",
+                    logout: "leave"
+                }
+            }
+        });
+
+        equal( Object.keys( auth1.modules ).length, 1, "Single Auth Module Created" );
+        equal( Object.keys( auth1.modules )[ 0 ], "module1", "Module name module1" );
+        equal( auth1.modules[ Object.keys( auth1.modules )[ 0 ] ].getBaseURL(), "http://customURL.com", "Base URL is http://customURL.com" );
+        equal( Object.keys( auth1.modules[ Object.keys( auth1.modules )[ 0 ] ].getEndpoints() ).length, 3, "Endpoints are set" );
+        equal( auth1.modules[ Object.keys( auth1.modules )[ 0 ] ].getEndpoints().enroll, "register", "Enroll endpoint is enroll" );
+        equal( auth1.modules[ Object.keys( auth1.modules )[ 0 ] ].getEndpoints().login, "go", "Login endpoint is go" );
+        equal( auth1.modules[ Object.keys( auth1.modules )[ 0 ] ].getEndpoints().logout, "leave", "Logout endpoint is leave" );
+    });
+
     test( "Authentication init", function() {
         expect( 2 );
 
@@ -10,6 +36,7 @@
         equal( Object.keys( auth1 ).length, 1, "Single Auth Module Created" );
         equal( Object.keys( auth1 )[ 0 ], "auth", "Module name auth" );
     });
+
     test( "Authentication Pipeline init", function() {
         expect( 3 );
 


### PR DESCRIPTION
https://github.com/aerogear/aerogear-js/blob/master/src/authentication/adapters/rest.js#L93 is not covered according code coverage results.

I've added a test for custom REST authentication module to verify that the settings (baseURL, endpoints) are set correctly and updated the doc comments in source code since the below doc comments are wrong:

``` js
auth.add( "module1", {
    baseURL: "http://customURL.com"
});
```

``` js
auth.add( "module2", {
    endpoints: {
    enroll: "register",
    login: "go",
    logout: "leave"
    }
});
```

In addition I'd like to ask if it makes sense to check whether the baseURL ends with / and if not to add it automatically. Currently, if the baseURL is X and enroll endpoint is Y the result URL for enrolling is XY. Shouldn't it be X/Y?
