### PR TITLE
DataMananger - Add fallback opt-out and user defined prefered adapters. ...

### DIFF
--- a/tests/unit/data-manager/data-manager-fallback.js
+++ b/tests/unit/data-manager/data-manager-fallback.js
@@ -78,4 +78,125 @@
         equal( dm.createTest32 instanceof AeroGear.DataManager.adapters.SessionLocal, true, "Fellback to SessionLocal" );
         equal( dm.createTest32.getAsync(), true, "SessionLocal should be in async mode since it fellback" );
     });
+
+    module( "DataManager Creation with fallbacks off", {
+        setup: function() {
+
+            for( var adapter in AeroGear.DataManager.validAdapters ) {
+                if( adapter === "IndexedDB" || adapter === "WebSQL") {
+                    delete AeroGear.DataManager.validAdapters[ adapter ];
+                }
+            }
+        },
+        teardown: function() {
+            AeroGear.DataManager.validAdapters = validAdapters;
+        }
+    });
+
+    test( "create WebSQL - No Fallback - name string", function() {
+        expect( 3 );
+
+        var dm = AeroGear.DataManager( { name: "createTest1", type: "WebSQL", settings: { fallback: false } } ).stores;
+        equal( Object.keys( dm ).length, 1, "Single Store created" );
+        equal( Object.keys( dm )[ 0 ], "createTest1", "Store Name createTest1" );
+        equal( dm.createTest1 instanceof AeroGear.DataManager.adapters.WebSQL, true, "Didn't Fallback" );
+    });
+
+    test( "create WebSQL - No Fallback - name array", function() {
+        expect( 6 );
+
+        var dm = AeroGear.DataManager([
+            {
+                name: "createTest21",
+                type: "WebSQL",
+                settings: {
+                    fallback: false
+                }
+            },
+            "createTest23"
+        ]).stores;
+
+        equal( Object.keys( dm ).length, 2, "2 Stores created" );
+        equal( Object.keys( dm )[ 0 ], "createTest21", "Store Name createTest21" );
+        equal( Object.keys( dm )[ 1 ], "createTest23", "Store Name createTest23" );
+        equal( dm.createTest21 instanceof AeroGear.DataManager.adapters.WebSQL, true, "Didn't Fallback" );
+        equal( dm.createTest23 instanceof AeroGear.DataManager.adapters.Memory, true, "No Fallback should happen" );
+        equal( dm.createTest23.getAsync(), false, "Memory should be in sync mode" );
+    });
+
+    test( "create - object", function() {
+        expect( 6 );
+
+        var dm = AeroGear.DataManager([
+            {
+                name: "createTest31"
+            },
+            {
+                name: "createTest32",
+                type: "WebSQL",
+                settings: {
+                    fallback: false
+                }
+            }
+        ]).stores;
+
+        equal( Object.keys( dm ).length, 2, "2 Stores created" );
+        equal( Object.keys( dm )[ 0 ], "createTest31", "Store Name createTest31" );
+        equal( Object.keys( dm )[ 1 ], "createTest32", "Store Name createTest32" );
+        equal( dm.createTest31 instanceof AeroGear.DataManager.adapters.Memory, true, "No Fallback should happen" );
+        equal( dm.createTest31.getAsync(), false, "Memory should be in sync mode" );
+        equal( dm.createTest32 instanceof AeroGear.DataManager.adapters.WebSQL, true, "Didn't Fallback" );
+    });
+
+    module( "DataManager Creation with fallbacks while supplying prefered list", {
+        setup: function() {
+
+            for( var adapter in AeroGear.DataManager.validAdapters ) {
+                if( adapter === "IndexedDB" || adapter === "WebSQL") {
+                    delete AeroGear.DataManager.validAdapters[ adapter ];
+                }
+            }
+        },
+        teardown: function() {
+            AeroGear.DataManager.validAdapters = validAdapters;
+        }
+    });
+
+    test( "create IndexedDB - Fallsback to Memory - name string", function() {
+        expect( 4 );
+
+        var dm = AeroGear.DataManager( { name: "createTest1", type: "IndexedDB", settings: { prefered: [ "Memory" ] } } ).stores;
+        equal( Object.keys( dm ).length, 1, "Single Store created" );
+        equal( Object.keys( dm )[ 0 ], "createTest1", "Store Name createTest1" );
+        equal( dm.createTest1 instanceof AeroGear.DataManager.adapters.Memory, true, "Fellback to Memory" );
+        equal( dm.createTest1.getAsync(), true, "SessionLocal should be in async mode since it fellback" );
+    });
+
+    test( "create IndexedDB and WebSQL - Fallsback to Memory - name array", function() {
+        expect( 10 );
+
+        var dm = AeroGear.DataManager([
+            {
+                name: "createTest21",
+                type: "WebSQL",
+                settings: { prefered: [ "Memory" ] }
+            },
+            {
+                name: "createTest22",
+                type: "IndexedDB"
+            },
+            "createTest23"
+        ]).stores;
+
+        equal( Object.keys( dm ).length, 3, "3 Stores created" );
+        equal( Object.keys( dm )[ 0 ], "createTest21", "Store Name createTest21" );
+        equal( Object.keys( dm )[ 1 ], "createTest22", "Store Name createTest22" );
+        equal( Object.keys( dm )[ 2 ], "createTest23", "Store Name createTest23" );
+        equal( dm.createTest21 instanceof AeroGear.DataManager.adapters.Memory, true, "Fellback to Memory" );
+        equal( dm.createTest22 instanceof AeroGear.DataManager.adapters.SessionLocal, true, "Fellback to SessionLocal" );
+        equal( dm.createTest21.getAsync(), true, "SessionLocal should be in async mode since it fellback" );
+        equal( dm.createTest22.getAsync(), true, "SessionLocal should be in async mode since it fellback" );
+        equal( dm.createTest23 instanceof AeroGear.DataManager.adapters.Memory, true, "No Fallback should happen" );
+        equal( dm.createTest23.getAsync(), false, "Memory should be in sync mode" );
+    });
 })( jQuery );


### PR DESCRIPTION
this is for https://issues.jboss.org/browse/AGJS-93

I've added 2 new config settings to Datamanager.
1. fallback - by default this is true, but if you want to opt-out of falling back to another adapter, the set this to false
2. prefered - you can specify what the fallback order should be,  defaults to `[ "IndexedDB", "WebSQL", "SessionLocal", "Memory" ]`
