### PR TITLE
AGJS-127 add debug support to STOMP notifier

### DIFF
--- a/src/notifier/adapters/stompws.js
+++ b/src/notifier/adapters/stompws.js
@@ -413,12 +413,18 @@ AeroGear.Notifier.adapters.stompws.prototype.debug = function( onData ) {
     ]);
  */
 AeroGear.Notifier.adapters.stompws.prototype.unsubscribe = function( channels ) {
-    var client = this.getClient();
+    var index, i,
+        client = this.getClient(),
+        thisChannels = this.getChannels();
 
     channels = AeroGear.isArray( channels ) ? channels : [ channels ];
-    for ( var i = 0; i < channels.length; i++ ) {
-        client.unsubscribe( channels[ i ].id );
-        this.removeChannel( channels[ i ] );
+    for ( i = 0; i < channels.length; i++ ) {
+        index = this.getChannelIndex( channels[ i ].address );
+        client.unsubscribe( thisChannels[ index ].id );
+        this.removeChannel( thisChannels[ index ] );
+        if ( channels[ i ].callback ) {
+            channels[ i ].callback.apply( this, arguments );
+        }
     }
 };
 


### PR DESCRIPTION
While creating a chat example using the aerogear-js STOMP notifier, I noticed that it is hard to print the data being sent and received from the STOMP library without the debug property support.
