### PR TITLE
Adding grunt-cli as a dependency.

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "grunt-contrib-qunit": "~0.1.1",
     "grunt-shell": "0.3.1",
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.13",
     "request": "~2.27.0",
     "jsdoc-aerogear": "~3.2.0-dev"
   },


### PR DESCRIPTION
Just thought it might be nice to not to install grunt-cli separately when starting afresh. Perhaps there is a good reason for not doing this that I'm not aware of.
