### PR TITLE
AGJS-201 Sinon.JS XMLHttpRequest#response workaround

### DIFF
--- a/tests/unit/authentication/authentication-rest.js
+++ b/tests/unit/authentication/authentication-rest.js
@@ -45,11 +45,9 @@ module("authentication - agXHR requests", {
                     case "json":
                         return JSON.parse( this.responseText );
                     case "arraybuffer":
-                        //TODO
-                        return undefined;
+                        throw new Error("unsupported");
                     case "blob":
-                        //TODO
-                        return undefined;
+                        throw new Error("unsupported");
                 }
             },
             configurable: true


### PR DESCRIPTION
not to be merged - just for discussion. rebase is needed and authentication unit tests should be improved according the test improvements @lholmquist made in AGJS-200 (reuse sinon.js server responses)

if you're fine with the workaround for Sinon.JS XMLHttpRequest#response, I'll update the PR so that the authentication unit tests are re-using the Sinon.JS server responses
