### PR TITLE
Update UnifiedPush Client

### DIFF
--- a/src/unifiedpush/aerogear.unifiedpush.js
+++ b/src/unifiedpush/aerogear.unifiedpush.js
@@ -60,6 +60,7 @@
             return new AeroGear.UnifiedPushClient( variantID, variantSecret, pushServerURL );
         }
 
+        pushServerURL = pushServerURL.substr(-1) === '/' ? pushServerURL : pushServerURL + '/';
         /**
             Performs a register request against the UnifiedPush Server using the given metadata which represents a client that wants to register with the server.
             @param {Object} settings The settings to pass in
@@ -91,7 +92,7 @@
                 contentType: "application/json",
                 dataType: "json",
                 type: "POST",
-                url: pushServerURL + "/rest/registry/device",
+                url: pushServerURL + "rest/registry/device",
                 headers: {
                     "Authorization": "Basic " + window.btoa(variantID + ":" + variantSecret)
                 },
@@ -117,7 +118,7 @@
                 contentType: "application/json",
                 dataType: "json",
                 type: "DELETE",
-                url: pushServerURL + "/rest/registry/device/" + deviceToken,
+                url: pushServerURL + "rest/registry/device/" + deviceToken,
                 headers: {
                     "Authorization": "Basic " + window.btoa(variantID + ":" + variantSecret)
                 },

--- a/tests/unit/unifiedpush/unifiedpush.js
+++ b/tests/unit/unifiedpush/unifiedpush.js
@@ -93,6 +93,29 @@
 
     });
 
+    test( "call register with proper settings with a trailing slash", function() {
+        expect(4);
+
+        var client, settings, ret;
+
+        settings = {};
+
+        settings.metadata = {
+            deviceToken: "12345"
+        };
+
+        client = AeroGear.UnifiedPushClient( "VARIANT_ID", "SECRET", "/api/pushserver/" );
+
+        ret = client.registerWithPushServer( settings );
+        var request = this.requests[0];
+
+        equal( ret instanceof Promise, true, "the return value should be an es6 promise" );
+        equal( request.url, "/api/pushserver" + "/rest/registry/device", "request.url should be the concatenation of push server url and device registry url" );
+        equal( request.method, "POST", "request.method should a POST request" );
+        equal( JSON.parse( request.requestBody ).deviceToken, "12345", "request body should have a request token param" );
+
+    });
+
     test( "call unregister", function() {
         expect(3);
 


### PR DESCRIPTION
This PR contains 2 JIRA items:

https://issues.jboss.org/browse/AGJS-206
- removing the double encode on the enpoint during an `unrgisterWithPushServer` call
- https://github.com/aerogear/aerogear-simplepush-server/pull/83 this pr will fix the issue with unregistering our SimplePush endpoints 

https://issues.jboss.org/browse/AGJS-207
- similar to this one: 10ff1a7aa69fa06dc739ec1bd1fd1f8ec7b0a7d0
