### PR TITLE
AGJS-209 - Update to Eclipse Paho MQTT v1.0.0 JavaScript Client

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -18,7 +18,7 @@
         "vertx": true,
         "SockJS": true,
         "Stomp": true,
-        "Messaging": true,
+        "Paho": true,
         "File": true,
         "sjcl": true,
         "crypto": true

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Some parts of AeroGear.js depend on external libraries which are not bundled in 
     * [vert.x Event Bus](http://vertx.io/downloads.html)
     * [SockJS](http://cdn.sockjs.org/)
 * **MQTT-WS**
-    * [Eclipse Paho mqttws31.js](http://git.eclipse.org/c/paho/org.eclipse.paho.mqtt.javascript.git/tree/src/mqttws31.js)
+    * [Eclipse Paho MQTT JavaScript Client](http://download.eclipse.org/paho/1.0/paho.javascript-1.0.0.zip)
 * **SimplePush**
     * See SimplePush Plugin
 


### PR DESCRIPTION
How to test?

Get https://github.com/tolis-e/aerogear-js-integration/tree/AGJS-209, execute `./servers/activemqtest/server.sh` and open the file `aerogear-js-integration/tests/notifier/mqttws.html` in a browser that supports web sockets
