### PR TITLE
Sync - Refactor and Remove Array Pattern Usage - AGJS-287

### DIFF
--- a/src/diff-sync/aerogear.diff-sync-client.js
+++ b/src/diff-sync/aerogear.diff-sync-client.js
@@ -36,7 +36,7 @@ AeroGear.DiffSyncClient = function ( config ) {
     var ws,
         sendQueue = [],
         that = this,
-        syncEngine = config.syncEngine || new AeroGear.DiffSyncEngine({name: 'jsonPatchEngine'}).engines.jsonPatchEngine;
+        syncEngine = config.syncEngine || new AeroGear.DiffSyncEngine();
 
     if ( config.serverUrl === undefined ) {
         throw new Error( "'config.serverUrl' must be specified" );

--- a/src/diff-sync/aerogear.diff-sync-engine.js
+++ b/src/diff-sync/aerogear.diff-sync-engine.js
@@ -18,32 +18,19 @@
     @status Experimental
     @constructs AeroGear.DiffSyncEngine
     @param {Object} config - A configuration
-    @param {function} [config.type = "jsonPatch"] - the type of sync engine, defaults to jsonPatch
-    @returns {object} diffSyncClient - The created DiffSyncClient
+    @param {String} [config.type = "jsonPatch"] - the type of sync engine, defaults to jsonPatch
+    @returns {Object} diffSyncEngine - The created DiffSyncEngine
  */
 AeroGear.DiffSyncEngine = function( config ) {
     if ( !( this instanceof AeroGear.DiffSyncEngine ) ) {
         return new AeroGear.DiffSyncEngine( config );
     }
-    // Super Constructor
-    AeroGear.Core.call( this );
 
     this.lib = "DiffSyncEngine";
     this.type = config ? config.type || "jsonPatch" : "jsonPatch";
 
-    /**
-        The name used to reference the collection of sync engines instances created from the adapters
-        @memberOf AeroGear.DiffSyncEngine
-        @type Object
-        @default modules
-     */
-    this.collectionName = "engines";
-
-    this.add( config );
+    return new AeroGear.DiffSyncEngine.adapters[ this.type ]();
 };
-
-AeroGear.DiffSyncEngine.prototype = AeroGear.Core;
-AeroGear.DiffSyncEngine.constructor = AeroGear.DiffSyncEngine;
 
 /**
     The adapters object is provided so that adapters can be added to the AeroGear.DiffSyncEngine namespace dynamically and still be accessible to the add method

--- a/tests/unit/sync/diff-sync-client.html
+++ b/tests/unit/sync/diff-sync-client.html
@@ -9,7 +9,6 @@
         <script type="text/javascript" src="../../vendor/qunit.js"></script>
         <script type="text/javascript" src="../../polyfill/bind-polyfill.js"></script>
         <script type="text/javascript" src="../../../src/aerogear.core.js"></script>
-        <script type="text/javascript" src="../../../external/diff-match-patch/diff_match_patch_uncompressed.js"></script>
         <script type="text/javascript" src="../../../src/diff-sync/aerogear.diff-sync-engine.js"></script>
         <script type="text/javascript" src="../../../src/diff-sync/engine-adapters/json-patch.js"></script>
         <script type="text/javascript" src="../../../src/diff-sync/aerogear.diff-sync-client.js"></script>

--- a/tests/unit/sync/diff-sync-engine-dmp.js
+++ b/tests/unit/sync/diff-sync-engine-dmp.js
@@ -3,19 +3,19 @@
     module( 'Sync Engine test' );
 
     test ( 'AeroGear.DiffSyncEngine should support creation without the new keyword', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         ok( engine , 'Should be no problem not using new when creating' );
     });
 
     test( 'add document', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing, doc = { id: 1234, clientId: 'client1', content: { name: 'Fletch' } };
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'}), doc = { id: 1234, clientId: 'client1', content: { name: 'Fletch' } };
         engine.addDocument( { id: 1234, clientId: 'client1', content: { name: 'Fletch' } } );
         var actualDoc = engine.getDocument( 1234 );
         equal( actualDoc.id, 1234, 'Document id should match' );
     });
 
     test( 'diff document', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         var doc = { id: 1234, clientId: 'client1', content: { name: 'Fletch' } };
         engine.addDocument( doc );
 
@@ -46,7 +46,7 @@
     });
 
     test( 'patch document', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         var doc = { id: 1234, clientId: 'client1', content: {name: 'Fletch' } };
         engine.addDocument( doc );
 
@@ -63,7 +63,7 @@
     });
 
     test( 'patch shadow - content is a String', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         var dmp = new diff_match_patch();
         var content = 'Fletch';
         var doc = { id: 1234, clientId: 'client1', content: content };
@@ -96,7 +96,7 @@
     });
 
     test( 'patch shadow - content is an Object', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         var dmp = new diff_match_patch();
         var content = { name: 'Fletch' };
         var doc = { id: 1234, clientId: 'client1', content: content };
@@ -129,7 +129,7 @@
     });
 
     test( 'already seen edit should be deleted', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         var dmp = new diff_match_patch();
         var content = { name: 'Fletch' };
         var doc = { id: 1234, clientId: 'client1', content: content };
@@ -160,7 +160,7 @@
     });
 
     test( 'restore from backup', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing', type: 'diffMatchPatch'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine({type: 'diffMatchPatch'});
         var dmp = new diff_match_patch();
         var content = { name: 'Fletch' };
         var doc = { id: 1234, clientId: 'client1', content: content };

--- a/tests/unit/sync/diff-sync-engine-json-patch.js
+++ b/tests/unit/sync/diff-sync-engine-json-patch.js
@@ -3,19 +3,19 @@
     module( 'JSON Patch - Sync Engine test' );
 
     test ( 'JSON Patch should be the default engine', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing' }).engines.thing;
+        var engine = AeroGear.DiffSyncEngine();
         equal( engine instanceof AeroGear.DiffSyncEngine.adapters.jsonPatch , true, 'Should be an instance of jsonpatch adapter' );
     });
 
     test( 'add document', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing'}).engines.thing, doc = { id: 1234, clientId: 'client1', content: { name: 'Fletch' } };
+        var engine = AeroGear.DiffSyncEngine(), doc = { id: 1234, clientId: 'client1', content: { name: 'Fletch' } };
         engine.addDocument( { id: 1234, clientId: 'client1', content: { name: 'Fletch' } } );
         var actualDoc = engine.getDocument( 1234 );
         equal( actualDoc.id, 1234, 'Document id should match' );
     });
 
     test( 'diff document', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine();
         var doc = { id: 1234, clientId: 'client1', content: { name: 'Fletch' } };
         engine.addDocument( doc );
 
@@ -42,7 +42,7 @@
     });
 
     test( 'patch document', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine();
         var doc = { id: 1234, clientId: 'client1', content: {name: 'Fletch' } };
         engine.addDocument( doc );
 
@@ -58,7 +58,7 @@
     });
 
     test( 'patch shadow - content is an Object', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine();
         var content = { name: 'Fletch' };
         var doc = { id: 1234, clientId: 'client1', content: content };
         var shadow;
@@ -89,7 +89,7 @@
     });
 
     test( 'already seen edit should be deleted', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine();
         var content = { name: 'Fletch' };
         var doc = { id: 1234, clientId: 'client1', content: content };
         var shadow;
@@ -119,7 +119,7 @@
     });
 
     test( 'restore from backup', function() {
-        var engine = AeroGear.DiffSyncEngine({name: 'thing'}).engines.thing;
+        var engine = AeroGear.DiffSyncEngine();
         var content = { name: 'Fletch' };
         var doc = { id: 1234, clientId: 'client1', content: content };
         var shadow;


### PR DESCRIPTION
As discussed on the ML, http://lists.jboss.org/pipermail/aerogear-dev/2015-February/010947.html and http://lists.jboss.org/pipermail/aerogear-dev/2015-February/010894.html
we are eventually going to get rid of the current "Array Pattern", (perhaps "List Pattern sounds better").

To test,  you can use this branch, https://github.com/lholmquist/aerogear-js-cookbook/tree/update-sync, of the example from the cookbook,  It has the updated js lib. 

