### PR TITLE
responseType was removed to support older version of XMLHttpRequest

### DIFF
--- a/src/unifiedpush/aerogear.unifiedpush.js
+++ b/src/unifiedpush/aerogear.unifiedpush.js
@@ -68,12 +68,6 @@
 
                 request.open( settings.type || "GET", settings.url, true, settings.username, settings.password );
 
-                /////////////////////////////////////////////////////////
-                //was removed to support older version of XMLHttpRequest
-                //responseType property for XMLHttpRequest object is added in the level 2 XMLHttpRequest Level
-                //which is included in html 5
-                //request.responseType = "json";
-                /////////////////////////////////////////////////////////
                 request.setRequestHeader( "Content-Type", "application/json" );
                 request.setRequestHeader( "Accept", "application/json" );
 

--- a/src/unifiedpush/aerogear.unifiedpush.js
+++ b/src/unifiedpush/aerogear.unifiedpush.js
@@ -68,7 +68,12 @@
 
                 request.open( settings.type || "GET", settings.url, true, settings.username, settings.password );
 
-                request.responseType = "json";
+                /////////////////////////////////////////////////////////
+                //was removed to support older version of XMLHttpRequest
+                //responseType property for XMLHttpRequest object is added in the level 2 XMLHttpRequest Level
+                //which is included in html 5
+                //request.responseType = "json";
+                /////////////////////////////////////////////////////////
                 request.setRequestHeader( "Content-Type", "application/json" );
                 request.setRequestHeader( "Accept", "application/json" );
 


### PR DESCRIPTION
Support Android version <4.4 which doesn't support html 5.
responseType property for XMLHttpRequest object is added in the level 2 XMLHttpRequest Level
which is included in html 5.
